### PR TITLE
add VIC-II bitmap and multicolor bitmap modes

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,5 +1,6 @@
 # Contributors
 - Mikael Borgbrant, mikael [dot] borgbrant [at] gmail [dot] com
+- Christian A. Weber, chris [at] gna [dot] ch
 
 # Contribution guidelines
 Please ensure your pull request adheres to the following guidelines:


### PR DESCRIPTION
Hi Mikael,

This patch adds support for bitmap modes (monochrome 320x200 and multicolor 160x200).

Thanks for this nice emulator! My goal is to get this demo working: https://www.sca.ch/c64/demos/flexible.html and to get rid of that horrible Vice/emscripten emulator.
 
-Chris